### PR TITLE
improve update recurring event

### DIFF
--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -1320,8 +1320,9 @@ module Viewpoint::EWS::SOAP
 
     # Insert item, enforce xmlns attribute if prefix is present
     def dispatch_field_item!(item, ns_prefix = nil)
-      item.values.first[:xmlns_attribute] = ns_prefix if ns_prefix
-      build_xml!(item)
+      item.each_pair {|k,v|
+        self.send("#{k}!", v)
+      }
     end
 
     def room_list!(cfg_prop)

--- a/lib/ews/soap/exchange_data_services.rb
+++ b/lib/ews/soap/exchange_data_services.rb
@@ -196,7 +196,7 @@ module Viewpoint::EWS::SOAP
     #           {:set_item_field => {
     #             :field_uRI => {:field_uRI => 'item:Subject'},
     #             # The following needs to conform to #build_xml! format for now
-    #             :calendar_item => { :sub_elements => [{:subject => {:text => 'Test Subject'}}]}
+    #             :calendar_item => { [{:subject => {:text => 'Test Subject'}}] }
     #           }}
     #         ]
     #       }


### PR DESCRIPTION
- cause: using `build_xml!` to build XML element. 
1.  issue: Some elements like body have 2 params (`body` as text and `body_type`) that can not be passed to the XML element (the only body can be passed ). 
2. recurrence can not be passed. Because the recurrence has many layers, the `build_xml!` passes only the first element after the key `sub_element`
- how to fix: use a loop like another function to let all data can be passed correctly.