### PR TITLE
custom update_item as cd_update_item for only event

### DIFF
--- a/lib/ews/soap/exchange_data_services.rb
+++ b/lib/ews/soap/exchange_data_services.rb
@@ -224,6 +224,28 @@ module Viewpoint::EWS::SOAP
       do_soap_request(req, response_class: EwsResponse)
     end
 
+    def cd_update_item(opts)
+      opts = opts.clone
+      [:item_changes].each do |k|
+        validate_param(opts, k, true)
+      end
+      req = build_soap! do |type, builder|
+        attribs = {}
+        attribs['MessageDisposition'] = opts[:message_disposition] if opts[:message_disposition]
+        attribs['ConflictResolution'] = opts[:conflict_resolution] if opts[:conflict_resolution]
+        attribs['SendMeetingInvitationsOrCancellations'] = opts[:send_meeting_invitations_or_cancellations] if opts[:send_meeting_invitations_or_cancellations]
+        if(type == :header)
+        else
+          builder.nbuild.UpdateItem(attribs) {
+            builder.nbuild.parent.default_namespace = @default_ns
+            builder.saved_item_folder_id!(opts[:saved_item_folder_id]) if opts[:saved_item_folder_id]
+            builder.cd_item_changes!(opts[:item_changes])
+          }
+        end
+      end
+      do_soap_request(req, response_class: EwsResponse)
+    end
+
     # Delete an item from a mailbox in the Exchange store
     # @see http://msdn.microsoft.com/en-us/library/aa580484(v=exchg.140).aspx
     #


### PR DESCRIPTION
- cause: using `build_xml!` to build XML element. 
1.  issue: Some elements like body have 2 params (`body` as text and `body_type`) that can not be passed to the XML element (the only body can be passed ). 
2. recurrence can not be passed. Because the recurrence has many layers, the `build_xml!` passes only the first element after the key `sub_element`
- how to fix: use a loop like another function to let all data can be passed correctly.

#6 is so risky so we need another function